### PR TITLE
bypass IComponentContext error

### DIFF
--- a/src/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperation.cs
@@ -108,8 +108,6 @@ namespace Autofac.Core.Resolving
         /// <exception cref="ArgumentNullException"/>
         public object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable<Parameter> parameters)
         {
-            if (_ended) throw new ObjectDisposedException(ResolveOperationResources.TemporaryContextDisposed, innerException: null);
-
             ++_callDepth;
 
             if (_activationStack.Count > 0) CircularDependencyDetector.CheckForCircularDependency(registration, _activationStack, _callDepth);

--- a/src/Autofac/Core/Resolving/ResolveOperationResources.Designer.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperationResources.Designer.cs
@@ -78,14 +78,5 @@ namespace Autofac.Core.Resolving {
                 return ResourceManager.GetString("MaxDepthExceeded", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This resolve operation has already ended. When registering components using lambdas, the IComponentContext &apos;c&apos; parameter to the lambda cannot be stored. Instead, either resolve IComponentContext again from &apos;c&apos;, or resolve a Func&lt;&gt; based factory to create subsequent components from..
-        /// </summary>
-        internal static string TemporaryContextDisposed {
-            get {
-                return ResourceManager.GetString("TemporaryContextDisposed", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Autofac/Core/Resolving/ResolveOperationResources.resx
+++ b/src/Autofac/Core/Resolving/ResolveOperationResources.resx
@@ -123,7 +123,4 @@
   <data name="MaxDepthExceeded" xml:space="preserve">
     <value>Probable circular dependency between factory-scoped components. Chain includes '{0}'</value>
   </data>
-  <data name="TemporaryContextDisposed" xml:space="preserve">
-    <value>This resolve operation has already ended. When registering components using lambdas, the IComponentContext 'c' parameter to the lambda cannot be stored. Instead, either resolve IComponentContext again from 'c', or resolve a Func&lt;&gt; based factory to create subsequent components from.</value>
-  </data>
 </root>


### PR DESCRIPTION
This is a work-around to bypass an Autofac error. (The solution suggested in the Autofac error message to resolve the error does not work.)

https://github.com/EQIS/trunkeqis/pull/1118
